### PR TITLE
Remove libgit2 dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,22 +19,6 @@ jobs:
         run: |
           go get -v -t -d ./...
 
-      - name: Build libgit2
-        run: |
-          cd /tmp
-          rm -fr libgit2-1.0.0.tar.gz libgit2-1.0.0
-          curl -Lv -O https://github.com/libgit2/libgit2/releases/download/v1.0.0/libgit2-1.0.0.tar.gz
-          tar xvfz libgit2-1.0.0.tar.gz
-          mkdir -p libgit2-1.0.0/build
-          cd libgit2-1.0.0/build
-          cmake ..
-          cmake --build .
-          sudo cp libgit2.pc /usr/lib/pkgconfig/
-          sudo cp libgit2.so.1.0.0 /usr/lib
-          sudo ln -s /usr/lib/libgit2.so.1.0.0 /usr/lib/libgit2.so.1.0
-          sudo ln -s /usr/lib/libgit2.so.1.0.0 /usr/lib/libgit2.so
-          sudo cp -aR ../include/* /usr/local/include/
-
       - name: Build
         run: go build -v .
 

--- a/config/config.go
+++ b/config/config.go
@@ -67,11 +67,12 @@ func findConfig(startDir string) (string, error) {
 	return "", &MountPointError{StartPoint: startDir, EndPoint: current}
 }
 
-// Parse a 'dots.(yml|yaml) in root of the git repository
+// Parse a `.dots.ya?ml`, starting from `start` progress upwards towards mount point.
+// If mount point is reached a `MountPointError` is returned.
 //
-// expects to find a 'dots.(yml|yaml)' file in the root of the git repository
-func Parse() (*DotsConfig, error) {
-	abs, err := filepath.Abs(".")
+// Expects to find `.dots.ya?ml` in a parent dirctory of the current directory
+func Parse(start string) (*DotsConfig, error) {
+	abs, err := filepath.Abs(start)
 	if err != nil {
 		return nil, err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -8,7 +8,6 @@ import (
 	"regexp"
 	"strings"
 
-	git "github.com/libgit2/git2go/v30"
 	"gopkg.in/yaml.v3"
 )
 
@@ -33,35 +32,51 @@ const (
 	configRegexp = `\.dots\.ya?ml`
 )
 
-// Finds .dots.ya?ml in a directory
-//
-// In the case both .dots.yaml and .dots.yml exist .dots.yml will be chosen
-func findConfigInDir(dir string) (string, error) {
-	files, err := ioutil.ReadDir(dir)
-	if err != nil {
-		return "", fmt.Errorf("failed to read directory `%s`: %w", dir, err)
-	}
+// MountPointError is an error dictating that when searching for a `.dots.ya?ml` file
+// one could not be found until it reached the mount point
+type MountPointError struct {
+	StartPoint string // Directory where search started at
+	EndPoint   string // Highest directory found that ended discovery, generally `/` (on Unix)
+}
 
+// Error returns a String stating that the start p
+func (mpe *MountPointError) Error() string {
+	return fmt.Sprintf("failed to find `.dots.ya?ml` starting from: `%s` reached mount point `%s`", mpe.StartPoint, mpe.EndPoint)
+}
+
+// Finds .dots.ya?ml going upward till root is reached
+//
+// Root is determined if calling filepath.Dir(current) results in the same
+// path as seen in this example https://golang.org/pkg/path/filepath/#Dir
+func findConfig(startDir string) (string, error) {
+	previous, current := "", startDir
 	configRegex := regexp.MustCompile(configRegexp)
-	for _, file := range files {
-		if configRegex.MatchString(file.Name()) {
-			return file.Name(), nil
+
+	for previous != current {
+		files, err := ioutil.ReadDir(current)
+		if err != nil {
+			return "", fmt.Errorf("failed to read directory `%s`: %w", current, err)
 		}
+		for _, file := range files {
+			if configRegex.MatchString(file.Name()) {
+				return filepath.Join(current, file.Name()), nil
+			}
+		}
+		previous, current = current, filepath.Dir(current)
 	}
-	return "", fmt.Errorf("'.dots.ya?ml' doesn't exist in dir %s", dir)
+	return "", &MountPointError{StartPoint: startDir, EndPoint: current}
 }
 
 // Parse a 'dots.(yml|yaml) in root of the git repository
 //
 // expects to find a 'dots.(yml|yaml)' file in the root of the git repository
 func Parse() (*DotsConfig, error) {
-	path, err := git.Discover(".", true, nil)
+	abs, err := filepath.Abs(".")
 	if err != nil {
-		return nil, fmt.Errorf("failed to discover git repository in `.`: %w", err)
+		return nil, err
 	}
-	gitDir := filepath.Dir(path)
-	root := filepath.Dir(gitDir)
-	configPath, err := findConfigInDir(root)
+
+	configPath, err := findConfig(abs)
 	if err != nil {
 		return nil, err
 	}
@@ -126,17 +141,4 @@ func ParseFile(path string) (*DotsConfig, error) {
 		}
 	}
 	return &dotsConf, nil
-}
-
-// ParseGit parses a 'dots.(yml|yaml) in root of the git repository
-//
-// expects to find a 'dots.(yml|yaml)' file in the root of the git repository
-func ParseGit(gitRepo *git.Repository) (*DotsConfig, error) {
-	dir := filepath.Dir(gitRepo.Workdir())
-	configPath, err := findConfigInDir(dir)
-	if err != nil {
-		return nil, err
-	}
-
-	return ParseFile(configPath)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -120,13 +120,23 @@ func TestValidParse(t *testing.T) {
 	}
 }
 
-func TestParse(t *testing.T) {
+func TestParseCWD(t *testing.T) {
 	abs, err := filepath.Abs(".")
 	assert.NoErrorf(t, err, "failed to setup config_test.go testing couldn't get absolute path of `.`: %w", err)
 	current, previous := abs, ""
 	for current != previous {
 		current, previous = filepath.Dir(current), current
 	}
-	_, err = config.Parse()
+	_, err = config.Parse(abs)
 	assert.EqualError(t, err, fmt.Sprintf("failed to find `.dots.ya?ml` starting from: `%s` reached mount point `%s`", abs, current))
+}
+
+func TestParseValid(t *testing.T) {
+	testData, err := pathToTestData()
+	assert.NoErrorf(t, err, "failed to setup config_test.go testing: %w", err)
+
+	abs, err := filepath.Abs(filepath.Join(testData, "bspwm"))
+	assert.NoErrorf(t, err, "failed to setup config_test.go testing couldn't get absolute path of `.`: %w", err)
+	_, err = config.Parse(abs)
+	assert.NoError(t, err)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/NickHackman/dots/config"
-	git "github.com/libgit2/git2go/v30"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -121,22 +120,13 @@ func TestValidParse(t *testing.T) {
 	}
 }
 
-func TestParseGit(t *testing.T) {
-	gitPath, err := git.Discover(".", true, nil)
-	assert.NoErrorf(t, err, "failed to discover git repository: %w", err)
-	repo, err := git.OpenRepository(gitPath)
-	assert.NoErrorf(t, err, "failed to open git repository: %w", err)
-	testData, err := pathToTestData()
-	assert.NoErrorf(t, err, "failed to setup config_test.go testing: %w", err)
-	root := filepath.Dir(testData)
-	_, err = config.ParseGit(repo)
-	assert.EqualError(t, err, fmt.Sprintf("'.dots.ya?ml' doesn't exist in dir %s", root))
-}
-
 func TestParse(t *testing.T) {
-	testData, err := pathToTestData()
-	assert.NoErrorf(t, err, "failed to setup config_test.go testing: %w", err)
-	root := filepath.Dir(testData)
+	abs, err := filepath.Abs(".")
+	assert.NoErrorf(t, err, "failed to setup config_test.go testing couldn't get absolute path of `.`: %w", err)
+	current, previous := abs, ""
+	for current != previous {
+		current, previous = filepath.Dir(current), current
+	}
 	_, err = config.Parse()
-	assert.EqualError(t, err, fmt.Sprintf("'.dots.ya?ml' doesn't exist in dir %s", root))
+	assert.EqualError(t, err, fmt.Sprintf("failed to find `.dots.ya?ml` starting from: `%s` reached mount point `%s`", abs, current))
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/NickHackman/dots
 go 1.14
 
 require (
-	github.com/libgit2/git2go/v30 v30.0.5
 	github.com/spf13/cobra v1.0.0
 	github.com/stretchr/testify v1.6.1
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,6 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/libgit2/git2go/v30 v30.0.5 h1:gxKqXOslpvYDZNC62f8GV34TAk0qw4wZ++IdYw8V9I4=
-github.com/libgit2/git2go/v30 v30.0.5/go.mod h1:YReiQ7xhMoyAL4ISYFLZt+OGqn6xtLqvTC1xJ9oAH7Y=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/testdata/.dots.yml
+++ b/testdata/.dots.yml
@@ -1,0 +1,12 @@
+name: YourName/dotfiles
+license: GPLv3
+URL: https://github.com/NickHackman/dots
+dotfiles:
+  - name: bspwm
+    description: A simple configuration file for the Binary Space Partition Window Manager
+    source: <root>/bspwm
+    destination: ~/.config/bspwm
+  - name: keybinds
+    description: Keybindings that escape <-> capslock and handle function keys
+    destination: "~"
+    install_children: true


### PR DESCRIPTION
Libgit2 massively increased build times, and is reasonably replaced by [vcs](https://github.com/golang/tools/tree/0a99049195aff55f007fc4dfd48e3ec2b4d5f602/go/vcs) for the purpose of Dots.